### PR TITLE
Fix bugs with using % instead of mod (or &)

### DIFF
--- a/src/stabilizer.jl
+++ b/src/stabilizer.jl
@@ -50,7 +50,7 @@ Conjugate of a stabilizer.
 """
 function Base.adjoint(stabilizer::Stabilizer)::Stabilizer
     conj = deepcopy(stabilizer)
-    conj.phase = (-conj.phase) % 4
+    conj.phase = mod(-conj.phase, 4)
     return conj
 end
 
@@ -72,11 +72,11 @@ function Base.:*(left::Stabilizer, right::Stabilizer)::Stabilizer
     left.qubits == right.qubits || return left
     qubits = left.qubits
     prod = Stabilizer(qubits)
-    prod.phase = (left.phase + right.phase) % 4
+    prod.phase = (left.phase + right.phase) & 3
     for n = 1:qubits
         (prod.X[n], prod.Z[n], phase) =
             _prodtab[((left.X[n]<<3)|(left.Z[n]<<2)|(right.X[n]<<1)|right.Z[n])+1]
-        prod.phase = (prod.phase + phase) % 4
+        prod.phase = (prod.phase + phase) & 3
     end
     return prod
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -144,17 +144,10 @@ function H(tab::AbstractArray{<:Integer}, qubit)
     # TODO: I'd say `tab` should be renamed to `tableau` (in other places as well)
     qubit_no = size(tab, 2)>>1
     for i in 1:qubit_no
-        x = tab[i, qubit]
-        z = tab[i, qubit+qubit_no]
-
-        # Apply phase correction if needed
-        if (x == 1) && (z == 1)
-            tab[i, 2*qubit_no+1] = (tab[i, 2*qubit_no+1] + 2) % 4
-        end
-
-        #Swap x and z
-        tab[i, qubit] = z
-        tab[i, qubit+qubit_no] = x
+        x, z = tab[i, qubit], tab[i, qubit+qubit_no]
+        x == 1 && z == 1 && (tab[i, end] ⊻= 2) # toggle bit 2 of phase if Y
+        # Swap bits
+        tab[i, qubit], tab[i, qubit+qubit_no] = z, x
     end
 end
 


### PR DESCRIPTION
% in Julia is the remainder operation, NOT the modulus operation, which means that it can produce negative results.
In this code, the result for the phases needs to be 0 - 3, so either `mod(phase, 4)` or `phase & 3` works correctly.
Also, instead of adding 2 and then masking, it is more efficient just to use an XOR operation (⊻ in Julia) to toggle the bit.
