### PR TITLE
Use structs to represent gates

### DIFF
--- a/src/Jabalizer.jl
+++ b/src/Jabalizer.jl
@@ -4,7 +4,10 @@ using Graphs, GraphPlot, LinearAlgebra
 using Documenter
 using PythonCall
 
-export Stabilizer, StabilizerState, GraphState
+export Stabilizer, StabilizerState, GraphState, Gates
+
+include("gates.jl")
+using .Gates
 
 const stim = PythonCall.pynew() # initially NULL
 const cirq = PythonCall.pynew() # initially NULL

--- a/src/execute_cirq.jl
+++ b/src/execute_cirq.jl
@@ -22,7 +22,7 @@ end
 Takes a stabilizer state and cirq circuit as input and applying the
 circuit to the stabilizer state.
 """
-function execute_cirq_circuit(state::Jabalizer.StabilizerState, circuit::Py)
+function execute_cirq_circuit(state::StabilizerState, circuit::Py)
     # Mapping of cirq gates to Jabalizer gates.
     # TODO: this seems to be inefficient, there is probably a better way to do that.
     # get ordered array of qubits
@@ -38,7 +38,7 @@ function execute_cirq_circuit(state::Jabalizer.StabilizerState, circuit::Py)
             # determines indicies of the qubit the gate is acting on
             qindex = [findfirst(isequal(q), qubits) for q in op.qubits]
             # Applies the Jabilizer gate corresponding to the Cirq gate.
-            gate_map[op.gate](state, qindex...)
+            gate_map[op.gate](qindex...)(state)
         end
     end
 end

--- a/src/stabilizer_gates.jl
+++ b/src/stabilizer_gates.jl
@@ -1,88 +1,20 @@
-"""
-    Id(state, qubit)
+# Pauli-I no-op operation (normally named I, but that conflicts with a LinearAlgebra name)
+function (g::Id)(state::StabilizerState) ; state ; end
 
-Apply I gate to a State on qubit.
-"""
-function Id(state::StabilizerState, qubit) end
+# One qubit gates
 
+function (g::P)(s::StabilizerState) ; s.is_updated = false ; s.simulator.s(g.qubit - 1) ; s ; end
+function (g::X)(s::StabilizerState) ; s.is_updated = false ; s.simulator.x(g.qubit - 1) ; s ; end
+function (g::Y)(s::StabilizerState) ; s.is_updated = false ; s.simulator.y(g.qubit - 1) ; s ; end
+function (g::Z)(s::StabilizerState) ; s.is_updated = false ; s.simulator.z(g.qubit - 1) ; s ; end
+function (g::H)(s::StabilizerState) ; s.is_updated = false ; s.simulator.h(g.qubit - 1) ; s ; end
 
-"""
-    P(state, qubit)
-
-Apply P gate to a state on qubit.
-"""
-function P(state::StabilizerState, qubit)
-    state.is_updated = false
-    state.simulator.s(qubit - 1)
-end
-
-"""
-    X(state, qubit)
-
-Apply X gate to a State.
-"""
-function X(state::StabilizerState, qubit)
-    state.is_updated = false
-    state.simulator.x(qubit - 1)
-end
-
-"""
-    Y(state, qubit)
-
-Apply Y gate to a State.
-"""
-function Y(state::StabilizerState, qubit)
-    state.is_updated = false
-    state.simulator.y(qubit - 1)
-end
-
-"""
-    Z(state, qubit)
-
-Apply Z gate to a State.
-"""
-function Z(state::StabilizerState, qubit)
-    state.is_updated = false
-    state.simulator.z(qubit - 1)
-end
-
-"""
-    H(state, qubit)
-
-Apply H gate to a State.
-"""
-function H(state::StabilizerState, qubit)
-    state.is_updated = false
-    state.simulator.h(qubit - 1)
-end
-
-
-"""
-    CNOT(state, control, target)
-
-Apply CNOT gate to a State.
-"""
-function CNOT(state::StabilizerState, control, target)
-    state.is_updated = false
-    state.simulator.cnot(control - 1, target - 1)
-end
-
-"""
-    CZ(state, control, target)
-
-Apply CZ gate to a State.
-"""
-function CZ(state::StabilizerState, control, target)
-    state.is_updated = false
-    state.simulator.cz(control - 1, target - 1)
-end
-
-"""
-    SWAP(state, first, second)
-
-Apply SWAP gate to a State.
-"""
-function SWAP(state::StabilizerState, qubit1, qubit2)
-    state.is_updated = false
-    state.simulator.swap(qubit1 - 1, qubit2 - 1)
+# Two qubit gates
+for typ in (:CNOT, :CZ, :SWAP)
+    op = Symbol(lowercase(string(typ)))
+    @eval function (g::$typ)(state::StabilizerState)
+        state.is_updated = false
+        state.simulator.$(op)(g.qubit1 - 1, g.qubit2 - 1)
+        state
+    end
 end

--- a/src/stabilizer_measurements.jl
+++ b/src/stabilizer_measurements.jl
@@ -10,11 +10,11 @@ MeasureZ(state::StabilizerState, qubit::Int) =
 
 function MeasureX(state::StabilizerState, qubit::Int)
     # Convert to |+>, |-> basis
-    H(state, qubit)
+    H(qubit)(state)
     # Measure along z (now x)
     outcome = MeasureZ(state, qubit)
     # Return to computational basis
-    H(state, qubit)
+    H(qubit)(state)
 
     return outcome
 end
@@ -23,15 +23,11 @@ function MeasureY(state::StabilizerState, qubit::Int)
 
     # Map Y eigenstates to X eigenstates
     # Note that P^dagger = ZP
-    Z(state, qubit)
-    P(state, qubit)
-    H(state, qubit)
+    state |> Z(qubit) |> P(qubit) |> H(qubit)
     # Measure along z (now y)
     outcome = MeasureZ(state, qubit)
-
     # Return to original basis
-    H(state, qubit)
-    P(state, qubit)
+    state |> H(qubit) |> P(qubit)
 
     return outcome
 end

--- a/src/stabilizer_state.jl
+++ b/src/stabilizer_state.jl
@@ -79,8 +79,7 @@ end
 
 function Base.display(state::StabilizerState)
     update_tableau(state)
-    println("Stabilizers (", length(state.stabilizers), ") stabilizers, ",
-        state.qubits, ") qubits):")
+    println("Stabilizers ($(length(state.stabilizers)) stabilizers, $(state.qubits) qubits):")
     println(state)
 end
 
@@ -103,10 +102,10 @@ function GraphToState(A::AbstractArray{<:Integer})::StabilizerState
     n = size(A, 1)
     state = ZeroState(n)
     for i = 1:n
-        H(state, i)
+        H(i)(state)
     end
     for i = 1:n, j = (i+1):n
-        A[i, j] == 1 && CZ(state, i, j)
+        A[i, j] == 1 && CZ(i, j)(state)
     end
     update_tableau(state)
     return state

--- a/src/util.jl
+++ b/src/util.jl
@@ -84,7 +84,7 @@ function ToGraph(state::StabilizerState)
         lead_sum = sum(tab[n:stabs, n])
 
         if lead_sum == 0
-            H(tab, n)
+            hadamard!(tab, n)
             push!(LOseq, ("H", n))
             tab = sortslices(tab, dims=1, rev=true)
             lead_sum = sum(tab[n:stabs, n])
@@ -136,11 +136,11 @@ end
 # TODO: Why this is the only operation we have for tabs?
 # TODO: Madhav – could you provide some extra context in the docstring.
 """
-    H(tab::Matrix{Int}, qubit)
+    hadamard!(tab::Matrix{Int}, qubit)
 
 Performs the Hadamard operation on the given tableau
 """
-function H(tab::AbstractArray{<:Integer}, qubit)
+function hadamard!(tab::AbstractArray{<:Integer}, qubit)
     # TODO: I'd say `tab` should be renamed to `tableau` (in other places as well)
     qubit_no = size(tab, 2)>>1
     for i in 1:qubit_no

--- a/test/old_tests.jl
+++ b/test/old_tests.jl
@@ -1,21 +1,20 @@
 @testset "Graph conversion" begin
 
     # Test GraphToState function
-    adjacency = [0 1 0 0 0
-        1 0 0 1 0
-        0 0 0 1 0
-        0 1 1 0 0
-        0 0 0 0 0]
+    adjacency =
+        [0 1 0 0 0
+         1 0 0 1 0
+         0 0 0 1 0
+         0 1 1 0 0
+         0 0 0 0 0]
 
     state_1 = Jabalizer.GraphToState(adjacency)
 
     state_2 = Jabalizer.ZeroState(5)
     for i in 1:5
-        Jabalizer.H(state_2, i)
+        H(i)(state_2)
     end
-    Jabalizer.CZ(state_2, 1, 2)
-    Jabalizer.CZ(state_2, 2, 4)
-    Jabalizer.CZ(state_2, 3, 4)
+    state_2 |> CZ(1, 2) |> CZ(2, 4) |> CZ(3, 4)
 
     @test isequal(state_1, state_2)
 
@@ -23,9 +22,9 @@
     # Prepare a 6 qubit GHZ state
     n = 6
     state = Jabalizer.ZeroState(n)
-    Jabalizer.H(state, 1)
+    H(1)(state)
     for i in 1:n-1
-        Jabalizer.CNOT(state, i, i + 1)
+        CNOT(i, i + 1)(state)
     end
 
     # Convert to graph state using ToGraph

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,6 @@
 using Jabalizer
+using Jabalizer.Gates
 using Test
-
 
 include("old_tests.jl")
 # include("end_to_end.jl")

--- a/test/stabilizer_measurements.jl
+++ b/test/stabilizer_measurements.jl
@@ -1,18 +1,18 @@
-const measurement_test_cases = (
-    ("0", Jabalizer.MeasureZ, 0, [0 1 0]),
-    ("1", Jabalizer.MeasureZ, 1, [0 1 2]),
-    ("+", Jabalizer.MeasureX, 0, [1 0 0]),
-    ("-", Jabalizer.MeasureX, 1, [1 0 2]),
-    ("+y", Jabalizer.MeasureY, 0, [1 1 0]),
-    ("-y", Jabalizer.MeasureY, 1, [1 1 2]),
-)
+const measurement_test_cases =
+    (("0", Jabalizer.MeasureZ, 0, [0 1 0]),
+     ("1", Jabalizer.MeasureZ, 1, [0 1 2]),
+     ("+", Jabalizer.MeasureX, 0, [1 0 0]),
+     ("-", Jabalizer.MeasureX, 1, [1 0 2]),
+     ("+y", Jabalizer.MeasureY, 0, [1 1 0]),
+     ("-y", Jabalizer.MeasureY, 1, [1 1 2]))
 
-const init_operations = Dict("0" => [],
-    "1" => [Jabalizer.X],
-    "+" => [Jabalizer.H],
-    "-" => [Jabalizer.X, Jabalizer.H],
-    "+y" => [Jabalizer.H, Jabalizer.P],
-    "-y" => [Jabalizer.X, Jabalizer.H, Jabalizer.P])
+const init_operations =
+    Dict("0" => [],
+         "1" => [Jabalizer.X],
+         "+" => [Jabalizer.H],
+         "-" => [Jabalizer.X, Jabalizer.H],
+         "+y" => [Jabalizer.H, Jabalizer.P],
+         "-y" => [Jabalizer.X, Jabalizer.H, Jabalizer.P])
 
 @testset "Measurements" begin
 
@@ -20,7 +20,7 @@ const init_operations = Dict("0" => [],
         @testset "Measurement $measurement_op on state $init_state_str" begin
             state = Jabalizer.ZeroState(1)
             for init_op in init_operations[init_state_str]
-                init_op(state, 1)
+                init_op(1)(state)
             end
             measurement = measurement_op(state, 1)
             @test measurement == target_output


### PR DESCRIPTION
This takes a different approach to represent gates.
Instead of functions that need to be called, they are structures that store the qubit(s) that they operate on.
They can be applied to a StabilizerState, and even chained (i.e. `state |> H(1) |> CZ(1,2)`)

