### PR TITLE
Fix Stim version at 1.10, bump Jabalizer to 0.4.1

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -3,4 +3,4 @@ python = ">=3.5,<4"
 cirq = "1.0.0"
 
 [pip.deps]
-stim = ">=1.10"
+stim = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Jabalizer"
 uuid = "5ba14d91-d028-496b-b148-c0fbc366f709"
 authors = ["Peter Rohde", "Madhav Krishnan Vijayan", "Scott Paul Jones"]
-version = "0.4.0"
+version = "0.4.1"
 
 [deps]
 Debugger = "31a5f54b-26ea-5ae9-a837-f05ce5417438"


### PR DESCRIPTION
The latest version of Stim (1.11) breaks Jabalizer - so the Stim version is fixed (for now) at 1.10.