### PR TITLE
Chore: Change dependency from cirq to cirq-core to limit number of dependencies

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -1,6 +1,6 @@
 [deps]
 python = ">=3.5,<4"
-cirq = "1.0.0"
+cirq-core = "1.0.0"
 
 [pip.deps]
 stim = "==1.10"


### PR DESCRIPTION
On M1 Mac I had troubles installing all the dependencies from cirq==1.0.0.
Changing to cirq-core helps + its better to limit number of dependencies in general.